### PR TITLE
Handle pure AMD syntax

### DIFF
--- a/ImportInserter.js
+++ b/ImportInserter.js
@@ -83,7 +83,7 @@ define(function (require, exports, module) {
     }
     
     var REQUIRE_LINE_REGEXP = /^(\s*)(\w.*)=(.+)(,|;)/;
-    var DEFINE_LINE_REGEXP = /define\([\[]?([\s\S]*?)[\s\S]?\],[\s\S]*?function[\s\S]?\(([\s\S]*?)\)/;
+    var DEFINE_LINE_REGEXP = /define\([\[]?([\s\S]*?)\],[\s\S]*?function[\s\S]?\(([\s\S]*?)\)/;
     
     function isFirstLine(match) {
         return match[2].indexOf("var ") !== -1;
@@ -338,6 +338,8 @@ define(function (require, exports, module) {
             var documentText = doc.getText();
             var match = DEFINE_LINE_REGEXP.exec(documentText);
             if (match && match[1]) {
+			
+
                 // FIXME : Will not work if match[2] is a match with the content of match[1]
                 var indexStartCaptureImport = match[0].lastIndexOf(match[1]);
                 var indexStartCaptureModule = match[0].lastIndexOf(match[2]);
@@ -357,12 +359,14 @@ define(function (require, exports, module) {
         *
         **/
         function stringAsArray(inputString) {
+                
+			var cleanupstring = inputString;
+            cleanupstring = cleanupstring.replace(/(\r\n|\n|\r)/gm, '');
+            cleanupstring = cleanupstring.replace(/\s+/g, '');
+            cleanupstring = cleanupstring.replace(/\t+/g, '');
             
-            inputString = inputString.replace(/(\r\n|\n|\r)/gm, '');
-            inputString = inputString.replace(/\s+/g, '');
-            inputString = inputString.replace(/\t+/g, '');
             
-            return (inputString === "") ?  [] : inputString.split(",");
+            return (cleanupstring === "") ?  [] : cleanupstring.split(",");
         }
     
         

--- a/ImportInserter.js
+++ b/ImportInserter.js
@@ -338,6 +338,7 @@ define(function (require, exports, module) {
             var documentText = doc.getText();
             var match = DEFINE_LINE_REGEXP.exec(documentText);
             if (match && match[1]) {
+                // FIXME : Will not work if match[2] is a match with the content of match[1]
                 var indexStartCaptureImport = match[0].lastIndexOf(match[1]);
                 var indexStartCaptureModule = match[0].lastIndexOf(match[2]);
                 return {    importsAsString : match[1],
@@ -364,22 +365,6 @@ define(function (require, exports, module) {
             return (inputString === "") ?  [] : inputString.split(",");
         }
     
-        /**
-        *   Check that the module is not already imported in the current file
-        **/
-        function checkForDuplicateModule() {
-        
-            
-        }
-        
-        /**
-        *   If the giben alias has already been chosen, rename it
-        *   TODO: Define a rename policy
-        **/
-        function renameDuplicate() {
-        
-            
-        }
         
         currentDependencies = getCurrentDependencies();
         if (currentDependencies) {

--- a/ImportInserter.js
+++ b/ImportInserter.js
@@ -28,18 +28,22 @@
  * Handles code generation & insertion
  */
 define(function (require, exports, module) {
+    
     "use strict";
     
     // Brackets modules
-    var EditorManager       = brackets.getModule("editor/EditorManager");
+    var EditorManager           = brackets.getModule("editor/EditorManager"),
+        ProjectManager          = brackets.getModule("project/ProjectManager");
     
     // TODO
     //  - deal with /test/spec
     //  - deal with special cases like Editor & NFS
     //  - insert in proper alphabetical order (**by rel-path**, not by bare module name) (adjusting "var" and ";" location as needed)
-    //  - handle NO existing import block - create new import block 'near' top of file
-    //  - remove folder-name assumptions
+    //  - handle NO existing import block - create new import block 'near' top of file 
+    //  - handle NO exisiting import amd depency list ( [] )
+    //  - remove folder-name assumptions ( There should be a way to get the loaded root repository from brackets )
     //      TODO: write up 'how to use prefs' docs while doing this
+    //  ( projectManager.getProjectRoot() give the loaded project root, but root path depends on the naming conventions it could be src, WebContent )
     //  - filter out or heavily down-rank non-.js files?
     //  - work in Brackets unit test code (files outside /src & with special /spec context)
     //  - bump out other lines' = signs if needed
@@ -47,13 +51,13 @@ define(function (require, exports, module) {
     //  - show toast for imports that were inserted outside of viewport area
     //  - support pre-canned import options for NodeJS standard APIs
     //  - recognize locally installed NodeJS packages (npm) & list those as options too
-    //  - support pure-AMD syntax (array of module names + list of arguments)
     //  - if file extension != .js, generate a "text!" require() instead
     
     
     // --------------------------------------------------------------------------------------------
     // Code generation & insertion
     
+    var test = ProjectManager.getInitialProjectPath();
     var REQUIRE_ROOT = "/src/";
     var EXTENSIONS_ROOT = "extensions/";  // atop REQUIRE_ROOT
 
@@ -80,6 +84,7 @@ define(function (require, exports, module) {
     }
     
     var REQUIRE_LINE_REGEXP = /^(\s*)(\w.*)=(.+)(,|;)/;
+    var DEFINE_LINE_REGEXP = /define\([\[]?([\s\S]*?)[\s\S]?,?[\s\S]?function[\s\S]?\(([\s\S]*?)\)/;
     
     function isFirstLine(match) {
         return match[2].indexOf("var ") !== -1;
@@ -103,6 +108,9 @@ define(function (require, exports, module) {
      *    extensionName: name of extension folder requirePath is relative to, if any
      */
     function parseModulePath(fullPath) {
+        
+        // TODO: Use makeProjectRelativeIfPossible ?
+        // TODO: Instead of folder assumption maybe we can search for the first index.html/.js lying in the project root ( ProjectManager.getProjectRoot() )
         var relPath = stripPrefix(fullPath, REQUIRE_ROOT, true);
         if (!relPath) {
             console.error("File lies outside Require root: " + fullPath);
@@ -141,6 +149,28 @@ define(function (require, exports, module) {
             extensionName: extensionName
         };
     }
+    
+    /**
+    *   Remove forbidden characters in variable name
+    *   TODO: camelCase
+    *   TODO: First letter lower case if singleton other otherwiser uppercase
+    *   @return String, variable name to use as import name
+    */
+    function moduleNameAsVariableName(moduleName) {
+        return moduleName.replace(/[^\w\s]/gi, '');
+    }
+    
+    /*
+    *   @param import path
+    *   If a Mapping is configured for the given import, it will return the alias of the module
+    *
+    */
+    function getMappedImport(importString) {
+        // TODO: Load require-config
+        // TODO: Search for a match
+        return importString;
+    }
+
     
     
     /**
@@ -285,13 +315,131 @@ define(function (require, exports, module) {
     }
     
     
+    
+    function doInsertAmd(editor, newImport) {
+        
+        var doc = editor.document,
+            currentDependencies,
+            imports,
+            moduleNames,
+            moduleInfos,
+            importsAsString,
+            finalDocContent;
+        
+        
+        /** 
+        *   Extract the list of import from the current document 
+        *   @return { 
+        *        startIndex : pos of the first import caracters
+        *        moduleNamesAsString : String representing the list of module names
+        *        importsAsString : String representing the list of imports
+        *       }
+        **/
+        function getCurrentDependencies() {
+            var documentText = doc.getText();
+            var match = DEFINE_LINE_REGEXP.exec(documentText);
+            if (match && match[1]) {
+                var indexStartCaptureImport = match[0].lastIndexOf(match[1]);
+                var indexStartCaptureModule = match[0].lastIndexOf(match[2]);
+                return {    importsAsString : match[1],
+                            moduleNamesAsString : match[2],
+                            startIndex : match.index + indexStartCaptureImport,
+                            startIndexForModules : match.index + indexStartCaptureModule };
+            }
+            return null;
+        }
+        
+        
+        /**
+        *
+        *   Build imports as an array, cleanup special chars
+        *   Remove line breaks, tabs and white spaces, will be added when import array is rebuilt
+        *
+        **/
+        function stringAsArray(inputString) {
+            
+            inputString = inputString.replace(/(\r\n|\n|\r)/gm, '');
+            inputString = inputString.replace(/\s+/g, '');
+            inputString = inputString.replace(/\t+/g, '');
+            
+            return (inputString === "") ?  [] : inputString.split(",");
+        }
+    
+        /**
+        *   Check that the module is not already imported in the current file
+        **/
+        function checkForDuplicateModule() {
+        
+            
+        }
+        
+        /**
+        *   If the giben alias has already been chosen, rename it
+        *   TODO: Define a rename policy
+        **/
+        function renameDuplicate() {
+        
+            
+        }
+        
+        currentDependencies = getCurrentDependencies();
+        if (currentDependencies) {
+            imports = currentDependencies.importsAsString ? stringAsArray(currentDependencies.importsAsString) : [];
+            moduleNames = currentDependencies.moduleNamesAsString ? stringAsArray(currentDependencies.moduleNamesAsString) : [];
+        } else {
+            // TODO: We must  search again with a modified regexp, than we shall start building the depencies array
+            return;
+        }
+        
+        // TODO: Depending on the extension we should search for the appropriate plugin, 
+        // maybe throw an error if that plugin does not exist within the project
+        moduleInfos = parseModulePath(newImport);
+       
+        imports.push("'" + getMappedImport(moduleInfos.requirePath) + "'");
+        moduleNames.push(moduleNameAsVariableName(moduleInfos.moduleName));
+        
+
+        importsAsString = currentDependencies.importsAsString;
+        finalDocContent = doc.getText().substr(0, currentDependencies.startIndex)
+            + "\n\t"
+            + imports.join(",\n\t")
+            + "\n"
+            + doc.getText().substr(currentDependencies.startIndex + importsAsString.length, (currentDependencies.startIndexForModules - (currentDependencies.startIndex + importsAsString.length)))
+            + moduleNames.join(", ")
+            + doc.getText().substr(currentDependencies.startIndexForModules + currentDependencies.moduleNamesAsString.length, (doc.getText().length - (currentDependencies.startIndexForModules + currentDependencies.moduleNamesAsString.length)));
+        
+        doc.setText(finalDocContent);
+        
+    }
+    
+    /*
+    *   Detect if the current file is using amd syntax.
+    *   return Boolean
+    **/
+    function isFileUsingAmdSyntax(doc) {
+        return doc.getText().match(/define\(\[/);
+    }
+    
+    
+    /**
+    *   Insert the correct import
+    *
+    **/
     function insertImport(importPath) {
         var editor = EditorManager.getActiveEditor();
+
         if (editor) {
             editor.document.batchOperation(function () {
-                doInsert(editor, importPath);
+                
+                if (isFileUsingAmdSyntax(editor.document)) {
+                    doInsertAmd(editor, importPath);
+                } else {
+                    doInsert(editor, importPath);
+                }
+                
             });
         }
+        
     }
     
     

--- a/ImportInserter.js
+++ b/ImportInserter.js
@@ -57,7 +57,6 @@ define(function (require, exports, module) {
     // --------------------------------------------------------------------------------------------
     // Code generation & insertion
     
-    var test = ProjectManager.getInitialProjectPath();
     var REQUIRE_ROOT = "/src/";
     var EXTENSIONS_ROOT = "extensions/";  // atop REQUIRE_ROOT
 

--- a/ImportInserter.js
+++ b/ImportInserter.js
@@ -83,7 +83,7 @@ define(function (require, exports, module) {
     }
     
     var REQUIRE_LINE_REGEXP = /^(\s*)(\w.*)=(.+)(,|;)/;
-    var DEFINE_LINE_REGEXP = /define\([\[]?([\s\S]*?)[\s\S]?,?[\s\S]?function[\s\S]?\(([\s\S]*?)\)/;
+    var DEFINE_LINE_REGEXP = /define\([\[]?([\s\S]*?)[\s\S]?\],[\s\S]*?function[\s\S]?\(([\s\S]*?)\)/;
     
     function isFirstLine(match) {
         return match[2].indexOf("var ") !== -1;

--- a/unittests.js
+++ b/unittests.js
@@ -50,6 +50,8 @@ define(function (require, exports, module) {
             SpecRunnerUtils.destroyMockEditor(testDocument);
         });
         
+        
+        
         var require3Lines =
             "define(function (require, exports, module) {\n" +
             "    \"use strict\";\n" +
@@ -80,6 +82,28 @@ define(function (require, exports, module) {
         
         var requireNone =
             "define(function (require, exports, module) {\n" +
+            "    \"use strict\";\n" +
+            "    \n" +
+            "    function foo() {\n" +
+            "        bar();\n" +
+            "    }\n" +
+            "    \n" +
+            "});";
+        
+                
+        var requirePureAmd =
+            "define(['require', 'jquery', 'backbone'], function (require, jquery, backbone) {\n" +
+            "    \"use strict\";\n" +
+            "    \n" +
+            "    function foo() {\n" +
+            "        bar();\n" +
+            "    }\n" +
+            "    \n" +
+            "});";
+        
+        
+        var requirePureAmdExpectedAfterImport =
+            "define([\n\t'require',\n\t'jquery',\r\n\t'backbone',\n\t'package/Editor'\n], function (require, jquery, backbone, Editor) {\n" +
             "    \"use strict\";\n" +
             "    \n" +
             "    function foo() {\n" +
@@ -333,6 +357,19 @@ define(function (require, exports, module) {
         });
         
         
+        // Amd Import
+        it("correclty detect amd and add to top depencies", function () {
+            
+            var startingText = requirePureAmd;
+            testDocument.setText(startingText);
+            
+            ImportInserter.insertImport("/foo/bar/src/package/Editor.js");
+            
+            var expectedText = requirePureAmdExpectedAfterImport;
+            //TODO: Fixme: Handle carriage return correctly
+            expect(testDocument.getText().replace(/(\r\n|\n|\r)/gm, '')).toBe(expectedText.replace(/(\r\n|\n|\r)/gm, ''));
+        });
+        
         // Non-JS files ---------------------------------------------------------------------------
         
         it("do something semi-useful when importing text file via require()", function () {
@@ -348,6 +385,9 @@ define(function (require, exports, module) {
             var expectedText = lines.join("\n");
             expect(testDocument.getText()).toBe(expectedText);
         });
+        
+        
+        
         
         
     }); // top-level describe()


### PR DESCRIPTION
Before the insertion, it will try to determine the syntax of the file.
If it has already an array of import using pure amd syntax, it will be added to it.

`define([..,..,..]`

Otherwise it will work the same as it used to.

Caveats  
- Still assume base folder name 
- Only works if import array is not empty
- Unit tests are still incomplete.

There are still  some todos that I have not had time to tackle.
- Check compliance of the variable that is used as module name, remove dash for example
- Check for duplicates imports and duplicates variable name
- Handle empty import array ( `define([], function( )` )

I am happy to here remarks and push an updated version
